### PR TITLE
Adding Spans for returned entities

### DIFF
--- a/app/information_extractor.py
+++ b/app/information_extractor.py
@@ -52,7 +52,7 @@ class AbstractIE(InterfaceInformationExtractor):
         preds = []
         for text in texts:
             entities = self.make_prediction(text)
-            entities = sorted(entities, key=lambda x: (x["start"], x["end"], x["label"], x["text"]))
+            entities = sorted(entities, key=lambda x: (x["start"], x["end"], x["label"]))
             preds.append(entities)
         return preds
 
@@ -89,7 +89,6 @@ class NavecIE(AbstractIE):
                     "start": start,
                     "end": end,
                     "label": label,
-                    "text": text[start:end],
                 }
             )
 
@@ -124,8 +123,7 @@ class RegexIE(AbstractIE):
                     {
                         "start": match.start(),
                         "end": match.end(),
-                        "label": label,
-                        "text": match.group(0),
+                        "label": label
                     }
                 )
         return found_entities

--- a/app/information_extractor.py
+++ b/app/information_extractor.py
@@ -1,8 +1,16 @@
 import re
+from pathlib import Path
+
 import yaml
 from navec import Navec
 from slovnet import NER
-from pathlib import Path
+
+
+NER_LABEL_MAP = {
+    "PER": "NAME",
+    "LOC": "ADDRESS",
+    "ORG": "ORGANIZATION",
+}
 
 
 class InterfaceInformationExtractor:
@@ -16,24 +24,12 @@ class InterfaceInformationExtractor:
     def predict(self, texts: list[str]):
         """
         Abstract method to predict entities from input texts.
-        
-        Args:
-            texts (list[str]): List of input texts to process
-            
-        Returns:
-            Predictions for the input texts
         """
         pass
 
     def preprocess_text(self, texts: list[str]):
         """
         Abstract method to preprocess input texts before prediction.
-        
-        Args:
-            texts (list[str]): List of input texts to preprocess
-            
-        Returns:
-            Preprocessed texts
         """
         pass
 
@@ -41,37 +37,28 @@ class InterfaceInformationExtractor:
 class AbstractIE(InterfaceInformationExtractor):
     """
     Abstract class for information extraction that implements basic functionality.
-    Inherits from InterfaceInformationExtractor.
     """
-    
-    def predict(self, texts: str | list[str]):
+
+    def predict(self, texts: str | list[str]) -> list[list[dict]]:
         """
-        Predicts entities from input text(s) and formats the output.
-        
-        Args:
-            texts (str | list[str]): Input text or list of texts to process
-            
-        Returns:
-            list[str]: List of predicted entities joined by semicolons for each input text
+        Predict entity spans from input text(s).
+
+        Returns one list of entities per input text. Every entity has
+        start/end offsets, label and text.
         """
         if isinstance(texts, str):
             texts = [texts]
+
         preds = []
-        for t in texts:
-            entites = self.make_prediction(t)
-            entites.sort()
-            preds.append(";".join(entites))
+        for text in texts:
+            entities = self.make_prediction(text)
+            entities = sorted(entities, key=lambda x: (x["start"], x["end"], x["label"], x["text"]))
+            preds.append(entities)
         return preds
 
-    def make_prediction(self, text: str) -> list[str]:
+    def make_prediction(self, text: str) -> list[dict]:
         """
         Abstract method to make predictions on a single text.
-        
-        Args:
-            text (str): Input text to process
-            
-        Returns:
-            list[str]: List of predicted entities
         """
         pass
 
@@ -80,74 +67,65 @@ class NavecIE(AbstractIE):
     """
     Implementation of information extraction using Navec embeddings and Slovnet NER.
     """
-    
+
     def __init__(self, navec_path, slovnet_path):
-        """
-        Initializes the NavecIE with pre-trained models.
-        
-        Args:
-            navec_path: Path to the Navec embeddings model
-            slovnet_path: Path to the SlovNet NER model
-        """
         navec = Navec.load(navec_path)
         self.ner = NER.load(slovnet_path)
         self.ner.navec(navec)
 
-    def make_prediction(self, text):
+    def make_prediction(self, text: str) -> list[dict]:
         """
-        Makes predictions using Slovnet NER model.
-        
-        Args:
-            text (str): Input text to process
-            
-        Returns:
-            list[str]: List of unique entity types found in the text
+        Makes span predictions using Slovnet NER model.
         """
-        return list(set([span.type for span in self.ner(text).spans]))
+        entities = []
+        markup = self.ner(text)
+
+        for span in markup.spans:
+            label = NER_LABEL_MAP.get(span.type, span.type)
+            start = span.start
+            end = span.stop
+            entities.append(
+                {
+                    "start": start,
+                    "end": end,
+                    "label": label,
+                    "text": text[start:end],
+                }
+            )
+
+        return entities
 
 
 class RegexIE(AbstractIE):
     """
     Implementation of information extraction using regular expressions.
     """
-    
-    def __init__(self, dictionary: dict[str:str] | str | Path):
-        """
-        Initializes the RegexIE with patterns dictionary.
-        
-        Args:
-            dictionary (dict[str:str] | str | Path): Dictionary of regex patterns and their labels,
-                                                    or path to YAML file containing patterns
-        """
+
+    def __init__(self, dictionary: dict[str, str] | str | Path):
         if isinstance(dictionary, str) or isinstance(dictionary, Path):
-            with open(dictionary, "r") as file:
+            with open(dictionary, "r", encoding="utf-8") as file:
                 dictionary = yaml.safe_load(file)
         self.regex2label = self._init_regexes(dictionary)
 
     def _init_regexes(self, regex2label: dict[str, str]):
         """
         Compiles regex patterns from the dictionary.
-        
-        Args:
-            regex2label (dict[str, str]): Dictionary mapping regex patterns to their labels
-            
-        Returns:
-            dict: Dictionary mapping compiled regex patterns to their labels
         """
-        return {re.compile(k): v for k, v in regex2label.items()}
+        return {re.compile(pattern): label for pattern, label in regex2label.items()}
 
-    def make_prediction(self, text: str | list[str]):
+    def make_prediction(self, text: str) -> list[dict]:
         """
-        Makes predictions using regex patterns.
-        
-        Args:
-            text (str | list[str]): Input text to process
-            
-        Returns:
-            list[str]: List of labels for matched patterns in the text
+        Makes span predictions using regex patterns.
         """
-        found_entites = []
+        found_entities = []
         for regex, label in self.regex2label.items():
-            if regex.search(text) is not None:
-                found_entites.append(label)
-        return found_entites
+            for match in regex.finditer(text):
+                found_entities.append(
+                    {
+                        "start": match.start(),
+                        "end": match.end(),
+                        "label": label,
+                        "text": match.group(0),
+                    }
+                )
+        return found_entities

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,7 @@ import os
 from fastapi import FastAPI
 from fastapi.responses import Response
 from app.information_extractor import NavecIE, RegexIE
-from app.utils import format_combined
+from app.utils import merge_entities
 from app.models import TritonRequest, OutputObject, TritonResponse
 
 app = FastAPI()
@@ -16,9 +16,6 @@ app.state.ie_list = [
 def get_version():
     """
     Get API version information.
-    
-    Returns:
-        dict: Dictionary containing API name, version and extensions
     """
     return {"name": "triton-like", "version": "1.0.0", "extensions": []}
 
@@ -27,9 +24,6 @@ def get_version():
 def ready():
     """
     Health check endpoint.
-    
-    Returns:
-        Response: 200 OK response indicating service is ready
     """
     return Response(status_code=200)
 
@@ -38,21 +32,19 @@ def ready():
 def infer(inputs: TritonRequest):
     """
     Perform inference on input data using multiple information extraction models.
-    
-    Args:
-        inputs (TritonRequest): Request object containing batch of input texts
-        
-    Returns:
-        TritonResponse: Response object containing combined predictions for each input
     """
-    request_batched = [x.data for x in inputs.inputs]
-    margin_predicts = []
-    for ie in app.state.ie_list:
-        margin_predicts.append([ie.predict(x) for x in request_batched])
-    combined = []
-    for one_text_preds in zip(*margin_predicts):
-        combined.append([format_combined(preds) for preds in zip(*one_text_preds)])
-    output_objs = [OutputObject(shape=[len(x)], data=x) for x in combined]
+    output_objs = []
+
+    for input_obj in inputs.inputs:
+        texts = input_obj.data
+        extractor_predictions = [ie.predict(texts) for ie in app.state.ie_list]
+
+        combined = []
+        for per_text_predictions in zip(*extractor_predictions):
+            combined.append(merge_entities(list(per_text_predictions)))
+
+        output_objs.append(OutputObject(shape=[len(combined)], data=combined))
+
     return TritonResponse(outputs=output_objs)
 
 
@@ -60,14 +52,6 @@ def infer(inputs: TritonRequest):
 def config():
     """
     Get model configuration.
-    
-    Returns:
-        dict: Dictionary containing model configuration parameters including:
-            - name
-            - platform 
-            - backend
-            - version policy
-            - max batch size
     """
     return {
         "name": "pie",

--- a/app/models.py
+++ b/app/models.py
@@ -27,20 +27,29 @@ class TritonRequest(BaseModel):
     inputs: list[InputObject]
 
 
+class EntitySpan(BaseModel):
+    """
+    Represents a detected entity span in the input text.
+
+    start is inclusive, end is exclusive, so text[start:end] must equal the
+    entity text.
+    """
+    start: int
+    end: int
+    label: str
+    text: str
+
+
 class OutputObject(BaseModel):
     """
-    Represents an output object from Triton model inference.
+    Represents an output object from Triton-like model inference.
 
-    Attributes:
-        name (str): Name of the output, defaults to "predicts"
-        datatype (str): Data type of the output, defaults to "BYTES"
-        shape (list[int]): Shape of the output tensor
-        data (list[str]): Output data as list of strings
+    data contains one list of EntitySpan objects for each input text.
     """
     name: str = "predicts"
-    datatype: str = "BYTES"
+    datatype: str = "JSON"
     shape: list[int]
-    data: list[str]
+    data: list[list[EntitySpan]]
 
 
 class TritonResponse(BaseModel):

--- a/app/models.py
+++ b/app/models.py
@@ -37,7 +37,6 @@ class EntitySpan(BaseModel):
     start: int
     end: int
     label: str
-    text: str
 
 
 class OutputObject(BaseModel):
@@ -47,9 +46,9 @@ class OutputObject(BaseModel):
     data contains one list of EntitySpan objects for each input text.
     """
     name: str = "predicts"
-    datatype: str = "JSON"
+    datatype: str = "BYTES"
     shape: list[int]
-    data: list[list[EntitySpan]]
+    data: list[str]
 
 
 class TritonResponse(BaseModel):

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,3 +1,5 @@
+import json
+
 def merge_entities(entity_groups: list[list[dict]]) -> list[dict]:
     """
     Merge entity spans returned by several extractors for the same text.
@@ -12,12 +14,11 @@ def merge_entities(entity_groups: list[list[dict]]) -> list[dict]:
             key = (
                 entity["start"],
                 entity["end"],
-                entity["label"],
-                entity["text"],
+                entity["label"]
             )
             if key in seen:
                 continue
             seen.add(key)
             merged.append(entity)
 
-    return sorted(merged, key=lambda x: (x["start"], x["end"], x["label"], x["text"]))
+    return json.dumps(sorted(merged, key=lambda x: (x["start"], x["end"], x["label"])))

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,15 +1,23 @@
-def format_combined(preds: list[str]):
+def merge_entities(entity_groups: list[list[dict]]) -> list[dict]:
     """
-    Formats a list of predictions into a single string.
+    Merge entity spans returned by several extractors for the same text.
 
-    Args:
-        preds (list[str]): List of string predictions
-
-    Returns:
-        str: Formatted string of predictions joined by semicolons.
-             Returns "NOT_FOUND" if all predictions are empty strings.
+    Exact duplicates are removed, then entities are sorted by span position.
     """
-    if all(x == "" for x in preds):
-        return "NOT_FOUND"
-    preds = [x for x in preds if x != ""]
-    return ";".join(preds)
+    merged = []
+    seen = set()
+
+    for entities in entity_groups:
+        for entity in entities:
+            key = (
+                entity["start"],
+                entity["end"],
+                entity["label"],
+                entity["text"],
+            )
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(entity)
+
+    return sorted(merged, key=lambda x: (x["start"], x["end"], x["label"], x["text"]))

--- a/configs/regex_ie.yml
+++ b/configs/regex_ie.yml
@@ -1,5 +1,5 @@
 \+?[78][-( ]?\d{3}\)?[- ]?\d{3}[- ]?\d{2}[- ]?\d{2} : "PHONE_NUMBER" 
-\b(?:\d{4}[- ]?){3}\d{4}\b : "BANK_CARD_NUMBER"
+\b(?:\d{4}[- ]?){3}\d{4}\b : "BANK_CARD"
 \b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b : "EMAIL"
 (?:t\.me|telegram\.me)/[a-zA-Z0-9_]+ : "TELEGRAM"
 vk\.com/[a-zA-Z0-9_]+ : "VK"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,26 +1,37 @@
-
 import pytest
+
+
+def make_input(examples):
+    return {
+        "inputs": [
+            {
+                "name": "text_input",
+                "shape": [len(examples), 1],
+                "datatype": "BYTES",
+                "data": examples,
+            }
+        ]
+    }
+
 
 @pytest.fixture
 def phone_number_collection():
-    phone_numbers = """+7(495)123-45-67
+    examples = """+7(495)123-45-67
 8-905-123-45-67
 89051234567
 +7(812)9999999
 8(812)999-99-99
-+7-911-777-88-99"""
-    phone_numbers = phone_numbers.split("\n")
-    input_json = {"inputs":[{"name":"text_input","shape":[len(phone_numbers),1],"datatype":"BYTES","data": phone_numbers}]}
-    return (input_json, ["PHONE_NUMBER"] * len(phone_numbers))
++7-911-777-88-99""".split("\n")
+    return make_input(examples), examples, ["PHONE_NUMBER"] * len(examples)
+
 
 @pytest.fixture
 def bank_card_collection():
     examples = """1234-5678-9012-3456
 1234 5678 9012 3456
-1234567890123456"""
-    examples = examples.split("\n")
-    input_json = {"inputs":[{"name":"text_input","shape":[len(examples),1],"datatype":"BYTES","data": examples}]}
-    return (input_json, ["BANK_CARD_NUMBER"] * len(examples))
+1234567890123456""".split("\n")
+    return make_input(examples), examples, ["BANK_CARD"] * len(examples)
+
 
 @pytest.fixture
 def emails_collection():
@@ -28,41 +39,36 @@ def emails_collection():
 test.email@domain.co.uk
 user123@gmail.ru
 test_email-88@test-domain.io
-mail@sub.domain.com"""
-    examples = examples.split("\n")
-    input_json = {"inputs":[{"name":"text_input","shape":[len(examples),1],"datatype":"BYTES","data": examples}]}
-    return (input_json, ["EMAIL"] * len(examples))
+mail@sub.domain.com""".split("\n")
+    return make_input(examples), examples, ["EMAIL"] * len(examples)
+
 
 @pytest.fixture
 def telegram_link_collection():
     examples = """t.me/test
 telegram.me/test_user123
-https://t.me/joinchat/"""
-    examples = examples.split("\n")
-    input_json = {"inputs":[{"name":"text_input","shape":[len(examples),1],"datatype":"BYTES","data": examples}]}
-    return (input_json, ["TELEGRAM"] * len(examples))
+https://t.me/joinchat/""".split("\n")
+    return make_input(examples), examples, ["TELEGRAM"] * len(examples)
+
 
 @pytest.fixture
 def vk_link_collection():
     examples = """vk.com/id123456
 vk.com/username
 https://vk.com/club987654
-vk.com/user123456"""
-    examples = examples.split("\n")
-    input_json = {"inputs":[{"name":"text_input","shape":[len(examples),1],"datatype":"BYTES","data": examples}]}
-    return (input_json, ["VK"] * len(examples))
+vk.com/user123456""".split("\n")
+    return make_input(examples), examples, ["VK"] * len(examples)
+
 
 @pytest.fixture
 def ner_collection():
     examples = """я живу в Москве
-    меня зовут Иванов Иван
-    я работаю в Общеобразовательной Школе 58"""
-    examples = examples.split("\n")
-    input_json = {"inputs":[{"name":"text_input","shape":[len(examples),1],"datatype":"BYTES","data": examples}]}
-    return (input_json, ["LOC", "PER", "ORG"])
+меня зовут Иванов Иван
+я работаю в Общеобразовательной Школе 58""".split("\n")
+    return make_input(examples), examples, ["ADDRESS", "NAME", "ORGANIZATION"]
+
 
 @pytest.fixture
 def multiple_entity_collection():
     examples = ["Меня зовут Иван Петров, мой номер +7(495)123-45-67"]
-    input_json = {"inputs":[{"name":"text_input","shape":[len(examples),1],"datatype":"BYTES","data": examples}]}
-    return (input_json, ["PER;PHONE_NUMBER"])
+    return make_input(examples), examples, [["NAME", "PHONE_NUMBER"]]

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -1,72 +1,122 @@
 from __future__ import annotations
+
 from fastapi.testclient import TestClient
 
 from app.main import app
 
 client = TestClient(app)
 
+
+def labels(entities):
+    return [entity["label"] for entity in entities]
+
+
+def assert_span_integrity(text, entities):
+    for entity in entities:
+        assert text[entity["start"]:entity["end"]] == entity["text"]
+
+
 def test_root():
     response = client.get("/v2")
     assert response.status_code == 200
-    assert response.json() == {"name":"triton-like",
-            "version":"1.0.0",
-            "extensions":[]
-            }
+    assert response.json() == {"name": "triton-like", "version": "1.0.0", "extensions": []}
+
 
 def test_health():
     response = client.get("/v2/health/ready")
     assert response.status_code == 200
 
+
 def test_config():
     response = client.get("/v2/models/pie/config")
-    assert response.json() == {"name": "pie", 
-                               "platform": "custom",
-                               "backend": "",
-                               "version_policy": "",
-                               "max_batch_size": 1}
-    
+    assert response.json() == {
+        "name": "pie",
+        "platform": "custom",
+        "backend": "",
+        "version_policy": "",
+        "max_batch_size": 1,
+    }
+
+
 def test_config_with_diff_batchsize():
     import os
+
     os.environ["MAX_BATCH_SIZE"] = "4"
     response = client.get("/v2/models/pie/config")
-    assert response.json() == {"name": "pie", 
-                               "platform": "custom",
-                               "backend": "",
-                               "version_policy": "",
-                               "max_batch_size": 4}
-    
+    assert response.json() == {
+        "name": "pie",
+        "platform": "custom",
+        "backend": "",
+        "version_policy": "",
+        "max_batch_size": 4,
+    }
+
+
 def test_phone_number_detection(phone_number_collection):
-    input_json, output_labels = phone_number_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = phone_number_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_label in zip(texts, predictions, output_labels):
+        assert labels(entities) == [expected_label]
+        assert_span_integrity(text, entities)
+
 
 def test_bank_card_number_detection(bank_card_collection):
-    input_json, output_labels = bank_card_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = bank_card_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_label in zip(texts, predictions, output_labels):
+        assert labels(entities) == [expected_label]
+        assert_span_integrity(text, entities)
+
 
 def test_email_detection(emails_collection):
-    input_json, output_labels = emails_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = emails_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_label in zip(texts, predictions, output_labels):
+        assert labels(entities) == [expected_label]
+        assert_span_integrity(text, entities)
+
 
 def test_telegram_link_detection(telegram_link_collection):
-    input_json, output_labels = telegram_link_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = telegram_link_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_label in zip(texts, predictions, output_labels):
+        assert labels(entities) == [expected_label]
+        assert_span_integrity(text, entities)
 
 
 def test_vk_link_detection(vk_link_collection):
-    input_json, output_labels = vk_link_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = vk_link_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_label in zip(texts, predictions, output_labels):
+        assert labels(entities) == [expected_label]
+        assert_span_integrity(text, entities)
+
 
 def test_ner_detection(ner_collection):
-    input_json, output_labels = ner_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = ner_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_label in zip(texts, predictions, output_labels):
+        assert labels(entities) == [expected_label]
+        assert_span_integrity(text, entities)
+
 
 def test_multi_entity_detection(multiple_entity_collection):
-    input_json, output_labels = multiple_entity_collection
-    output = client.post("/v2/models/pie/infer", json=input_json)
-    assert output_labels == output.json()["outputs"][0]["data"]
+    input_json, texts, output_labels = multiple_entity_collection
+    response = client.post("/v2/models/pie/infer", json=input_json)
+    predictions = response.json()["outputs"][0]["data"]
+
+    for text, entities, expected_labels in zip(texts, predictions, output_labels):
+        assert sorted(labels(entities)) == sorted(expected_labels)
+        assert_span_integrity(text, entities)


### PR DESCRIPTION
## What changed
- Return entity spans with `start`, `end`, `label`, `text` instead of semicolon-separated labels.
- Map Slovnet `PER/LOC/ORG` to project labels `NAME/ADDRESS/ORGANIZATION`.
- Return regex matches with exact offsets via `finditer`.
- Rename `BANK_CARD_NUMBER` to `BANK_CARD`.
- Update API tests for span integrity.

## Why
This makes PIE output compatible with span-level validation and future PII anonymization.
